### PR TITLE
Add Basic XDG Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +63,9 @@ dependencies = [
  "serde",
  "serde_repr",
  "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "zbus",
 ]
 
@@ -329,6 +347,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +556,21 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -835,6 +883,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1461,6 +1533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,6 +1689,12 @@ checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1821,6 +1914,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2093,7 @@ dependencies = [
  "ashpd",
  "node-bindgen",
  "thiserror",
+ "tokio",
  "uiohook-sys",
  "xcb",
  "xkbcommon",
@@ -2078,6 +2182,66 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 0.38.34",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
+dependencies = [
+ "bitflags 2.6.0",
+ "rustix 0.38.34",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62989625a776e827cc0f15d41444a3cea5205b963c3a25be48ae1b52d6b4daaa"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.34.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
 
 [[package]]
 name = "web-sys"
@@ -2309,7 +2473,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "bitflags 1.3.2",
  "libc",
- "quick-xml",
+ "quick-xml 0.30.0",
  "x11",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ node-bindgen = { version = "6.0", optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 xcb = { version = "1.4.0", features = ["x11", "xkb", "as-raw-xcb-connection"] }
 xkbcommon = { version = "0.8.0", features = ["x11"] }
-ashpd = "0.9.1"
+ashpd = { version = "0.9.1", features = ["wayland"] }
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread"] }
 
 [features]
 default = ["node"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ node-bindgen = { version = "6.0", optional = true }
 xcb = { version = "1.4.0", features = ["x11", "xkb", "as-raw-xcb-connection"] }
 xkbcommon = { version = "0.8.0", features = ["x11"] }
 ashpd = { version = "0.9.1", features = ["wayland"] }
-tokio = { version = "1", default-features = false, features = ["rt-multi-thread"] }
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "sync"] }
 
 [features]
 default = ["node"]

--- a/lib/venbind.d.ts
+++ b/lib/venbind.d.ts
@@ -1,5 +1,5 @@
 export class Venbind {
-    startKeybinds(window_id: BigInt | null, callback: (x: number) => void): Promise<void>;
+    startKeybinds(window_id: BigInt | null, display_id: BigInt | null, callback: (x: number) => void): Promise<void>;
     registerKeybind(keybind: string, keybindId: number): void;
     unregisterKeybind(keybindId: number): void;
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,4 @@
+use ashpd::Error;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, VenbindError>;
@@ -7,5 +8,15 @@ pub enum VenbindError {
     #[error("Something went wrong with libuiohook")] // TODO: better log
     LibUIOHookError,
     #[error("{0}")]
-    Message(String)
+    Message(String),
+    #[cfg(all(target_os = "linux"))]
+    #[error("ashpd error: {0}")]
+    AshPdError(ashpd::Error),
+}
+
+#[cfg(all(target_os = "linux"))]
+impl From<ashpd::Error> for VenbindError {
+    fn from(value: Error) -> Self {
+        VenbindError::AshPdError(value)
+    }
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -5,10 +5,10 @@ use node_bindgen::derive::node_bindgen;
 use crate::structs::{KeybindId, KeybindTrigger};
 
 #[node_bindgen]
-async fn start_keybinds<F: Fn(KeybindId)>(window_id: Option<u32>, callback: F) {
+async fn start_keybinds<F: Fn(KeybindId)>(window_id: Option<usize>, display_id: Option<usize>, callback: F) {
     let (tx, rx) = channel::<KeybindTrigger>();
     thread::spawn(|| {
-        crate::start_keybinds(None, tx);
+        crate::start_keybinds(window_id, display_id, tx);
     });
     loop {
         match rx.recv() {

--- a/src/js.rs
+++ b/src/js.rs
@@ -5,7 +5,11 @@ use node_bindgen::derive::node_bindgen;
 use crate::structs::{KeybindId, KeybindTrigger};
 
 #[node_bindgen]
-async fn start_keybinds<F: Fn(KeybindId)>(window_id: Option<usize>, display_id: Option<usize>, callback: F) {
+async fn start_keybinds<F: Fn(KeybindId)>(
+    window_id: Option<u64>,
+    display_id: Option<u64>,
+    callback: F,
+) {
     let (tx, rx) = channel::<KeybindTrigger>();
     thread::spawn(|| {
         crate::start_keybinds(window_id, display_id, tx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::mpsc::Sender;
 use platform::*;
 use structs::{KeybindId, KeybindTrigger};
 
-pub fn start_keybinds(window_id: Option<usize>, display_id: Option<usize>, tx: Sender<KeybindTrigger>) {
+pub fn start_keybinds(window_id: Option<u64>, display_id: Option<u64>, tx: Sender<KeybindTrigger>) {
     start_keybinds_internal(window_id, display_id, tx).unwrap();
 }
 
@@ -34,7 +34,7 @@ mod tests {
         thread::spawn(|| {
             start_keybinds(None, None, tx);
         });
-        thread::sleep(std::time::Duration::from_secs(1));
+        thread::sleep(std::time::Duration::from_secs(2));
         register_keybind("shift+alt+m".to_string(), 1);
         register_keybind("shift+ctrl+a".to_string(), 2);
         loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ use std::sync::mpsc::Sender;
 use platform::*;
 use structs::{KeybindId, KeybindTrigger};
 
-pub fn start_keybinds(window_id: Option<u64>, tx: Sender<KeybindTrigger>) {
-    start_keybinds_internal(window_id, tx).unwrap();
+pub fn start_keybinds(window_id: Option<usize>, display_id: Option<usize>, tx: Sender<KeybindTrigger>) {
+    start_keybinds_internal(window_id, display_id, tx).unwrap();
 }
 
 pub fn register_keybind(keybind: String, id: KeybindId) {
@@ -32,8 +32,9 @@ mod tests {
     fn demo() {
         let (tx, rx) = channel::<KeybindTrigger>();
         thread::spawn(|| {
-            start_keybinds(None, tx);
+            start_keybinds(None, None, tx);
         });
+        thread::sleep(std::time::Duration::from_secs(1));
         register_keybind("shift+alt+m".to_string(), 1);
         register_keybind("shift+ctrl+a".to_string(), 2);
         loop {

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -2,7 +2,8 @@ use core::panic;
 use std::cell::RefCell;
 use std::sync::{mpsc::Sender, Mutex};
 use std::sync::{LazyLock, OnceLock};
-
+use std::sync::atomic::{AtomicBool, Ordering};
+use ashpd::WindowIdentifier;
 use uiohook_sys::{
     _event_type_EVENT_KEY_PRESSED, _uiohook_event, hook_run, hook_set_dispatch_proc,
     UIOHOOK_SUCCESS,
@@ -17,54 +18,103 @@ use crate::utils;
 static KEYBINDS: LazyLock<Mutex<Keybinds>> = LazyLock::new(|| Mutex::new(Keybinds::default()));
 static TX: OnceLock<Sender<KeybindTrigger>> = OnceLock::new();
 
+static IS_USING_PORTAL: AtomicBool = AtomicBool::new(true);
+
 thread_local! {
     static XKBCOMMON_STATE: RefCell<Option<State>> = RefCell::new(None);
 }
 
+// window_id should be either a XID if using an X server or a wayland surface handle
+// display_id should be a wayland display handle, or None if using X
 pub(crate) fn start_keybinds_internal(
-    window_id: Option<u64>,
+    window_id: Option<usize>,
+    display_id: Option<usize>,
     tx: Sender<KeybindTrigger>,
 ) -> Result<()> {
     TX.set(tx).unwrap();
-    if utils::is_wayland() {
-        return Err(VenbindError::Message("todo".to_owned()));
-    }
-    let (connection, _screen) =
-        xcb::Connection::connect_with_extensions(None, &[Extension::Xkb], &[]).unwrap();
-    let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
-    xkb::x11::setup_xkb_extension(
-        &connection,
-        xkb::x11::MIN_MAJOR_XKB_VERSION,
-        xkb::x11::MIN_MINOR_XKB_VERSION,
-        xkb::x11::SetupXkbExtensionFlags::NoFlags,
-        &mut 0,
-        &mut 0,
-        &mut 0,
-        &mut 0,
-    );
-    let device_id = xkb::x11::get_core_keyboard_device_id(&connection);
-    let keymap = xkb::x11::keymap_new_from_device(
-        &context,
-        &connection,
-        device_id,
-        xkb::KEYMAP_COMPILE_NO_FLAGS,
-    );
-    drop(connection);
-    // don't make a state with an xcb connection (state_new_from_device) so it only chooses the first layout
-    // TODO: if someone's first selected layout is not a latin based layout horrible things happen
-    let state = xkb::State::new(&keymap);
-    XKBCOMMON_STATE.replace(Some(state));
-    unsafe {
-        hook_set_dispatch_proc(Some(dispatch_proc));
-        if hook_run() != UIOHOOK_SUCCESS as i32 {
-            return Err(VenbindError::LibUIOHookError);
+    let result = xdg_start_keybinds(window_id, display_id);
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            eprintln!("Failed to start using XDG Desktop Portals: {}", e);
+            IS_USING_PORTAL.store(false, Ordering::Relaxed);
+            xcb_start_keybinds()
         }
-    };
-    Ok(())
+    }
+}
+
+pub(crate) fn register_keybind_internal(keybind: String, id: KeybindId) -> Result<()> {
+    if IS_USING_PORTAL.load(Ordering::Relaxed) {
+        Err(VenbindError::Message("todo".to_owned()))
+    } else {
+        xcb_register_keybind(keybind, id)
+    }
+}
+
+pub(crate) fn unregister_keybind_internal(id: KeybindId) -> Result<()> {
+    if IS_USING_PORTAL.load(Ordering::Relaxed) {
+        Err(VenbindError::Message("todo".to_owned()))
+    } else {
+        xcb_unregister_keybind(id)
+    }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dispatch_proc(event_ref: *mut _uiohook_event) {
+pub unsafe extern "C" fn xdg_displatch_proc(event_ref: *mut _uiohook_event) {
+
+}
+
+#[inline]
+fn convert_to_pointer<T>(value: Option<usize>) -> *mut T {
+    assert_eq!(size_of::<usize>(), size_of::<*mut T>());
+    match value {
+        Some(value) => value as *mut T,
+        None => std::ptr::null_mut(),
+    }
+}
+
+fn xdg_start_keybinds(
+    window_id: Option<usize>,
+    display_id: Option<usize>,
+) -> Result<()> {
+    use ashpd::desktop::global_shortcuts::*;
+
+    if window_id.is_none() {
+        return Err(VenbindError::Message("Window ID is Not Valid".to_owned()));
+    }
+
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => return Err(VenbindError::Message("Failed to create tokio runtime".to_owned())),
+    };
+
+    let res = runtime.block_on(async {
+        let portal = GlobalShortcuts::new().await?;
+
+        let session = portal.create_session().await?;
+
+        let window_handle = if utils::is_wayland() {
+            if display_id.is_none() {
+                return Err(VenbindError::Message("Wayland requires a valid display handle".to_owned()));
+            }
+            unsafe {
+                WindowIdentifier::from_wayland_raw(convert_to_pointer(window_id), convert_to_pointer(display_id)).await
+            }
+        } else {
+            WindowIdentifier::from_xid(window_id.unwrap() as _)
+        };
+
+        Ok((portal, session, window_handle))
+    });
+
+    match res {
+        Ok((portal, session, window_handle)) => { Ok(()) },
+        Err(e) => Err(e),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn xcb_dispatch_proc(event_ref: *mut _uiohook_event) {
     let event = *event_ref;
     if event.type_ == _event_type_EVENT_KEY_PRESSED {
         XKBCOMMON_STATE.with(|state| {
@@ -92,19 +142,49 @@ pub unsafe extern "C" fn dispatch_proc(event_ref: *mut _uiohook_event) {
     }
 }
 
-pub(crate) fn register_keybind_internal(keybind: String, id: KeybindId) -> Result<()> {
-    if utils::is_wayland() {
-        return Err(VenbindError::Message("todo".to_owned()));
-    }
+fn xcb_start_keybinds() -> Result<()> {
+    let (connection, _screen) =
+        xcb::Connection::connect_with_extensions(None, &[Extension::Xkb], &[]).unwrap();
+    let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+    xkb::x11::setup_xkb_extension(
+        &connection,
+        xkb::x11::MIN_MAJOR_XKB_VERSION,
+        xkb::x11::MIN_MINOR_XKB_VERSION,
+        xkb::x11::SetupXkbExtensionFlags::NoFlags,
+        &mut 0,
+        &mut 0,
+        &mut 0,
+        &mut 0,
+    );
+    let device_id = xkb::x11::get_core_keyboard_device_id(&connection);
+    let keymap = xkb::x11::keymap_new_from_device(
+        &context,
+        &connection,
+        device_id,
+        xkb::KEYMAP_COMPILE_NO_FLAGS,
+    );
+    drop(connection);
+    // don't make a state with an xcb connection (state_new_from_device) so it only chooses the first layout
+    // TODO: if someone's first selected layout is not a latin based layout horrible things happen
+    let state = xkb::State::new(&keymap);
+    XKBCOMMON_STATE.replace(Some(state));
+    unsafe {
+        hook_set_dispatch_proc(Some(xcb_dispatch_proc));
+        if hook_run() != UIOHOOK_SUCCESS as i32 {
+            return Err(VenbindError::LibUIOHookError);
+        }
+    };
+    Ok(())
+}
+
+fn xcb_register_keybind(keybind: String, id: KeybindId) -> Result<()> {
     let keybind = Keybind::from_string(keybind);
     let mut keybinds = KEYBINDS.lock().unwrap();
     keybinds.register_keybind(keybind, id);
     Ok(())
 }
-pub(crate) fn unregister_keybind_internal(id: KeybindId) -> Result<()> {
-    if utils::is_wayland() {
-        return Err(VenbindError::Message("todo".to_owned()));
-    }
+
+fn xcb_unregister_keybind(id: KeybindId) -> Result<()> {
     let mut keybinds = KEYBINDS.lock().unwrap();
     keybinds.unregister_keybind(id);
     Ok(())

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -73,11 +73,9 @@ pub(crate) fn register_keybind_internal(keybind: String, id: KeybindId) -> Resul
 }
 
 pub(crate) fn unregister_keybind_internal(id: KeybindId) -> Result<()> {
-    if IS_USING_PORTAL.load(Ordering::Relaxed) {
-        Err(VenbindError::Message("todo".to_owned()))
-    } else {
-        xcb_unregister_keybind(id)
-    }
+    let mut keybinds = KEYBINDS.lock().unwrap();
+    keybinds.unregister_keybind(id);
+    Ok(())
 }
 
 #[inline]
@@ -258,11 +256,5 @@ fn xcb_start_keybinds() -> Result<()> {
 
 fn xcb_register_keybind(keybind: String, id: KeybindId) -> Result<()> {
     generic_register_keybind(keybind, id);
-    Ok(())
-}
-
-fn xcb_unregister_keybind(id: KeybindId) -> Result<()> {
-    let mut keybinds = KEYBINDS.lock().unwrap();
-    keybinds.unregister_keybind(id);
     Ok(())
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -101,14 +101,14 @@ fn xdg_start_keybinds(window_id: Option<u64>, display_id: Option<u64>) -> Result
 
         let window_handle = if utils::is_wayland() {
             if window_id.is_none() || display_id.is_none() {
-                WindowIdentifier::default();
-            }
-            unsafe {
-                WindowIdentifier::from_wayland_raw(
-                    convert_to_pointer(window_id),
-                    convert_to_pointer(display_id),
-                )
-                .await
+                WindowIdentifier::default()
+            } else {
+                unsafe {
+                    WindowIdentifier::from_wayland_raw(
+                        convert_to_pointer(window_id),
+                        convert_to_pointer(display_id),
+                    ).await
+                }
             }
         } else {
             if window_id.is_none() {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -9,7 +9,7 @@ pub struct Keybinds {
 
 pub enum KeybindTrigger {
     Pressed(KeybindId),
-    Released(KeybindId)
+    Released(KeybindId),
 }
 
 #[derive(PartialEq, Eq, Hash, Debug)]
@@ -31,7 +31,7 @@ impl Keybind {
             "shift" => shift = true,
             "alt" => alt = true,
             "ctrl" => ctrl = true,
-            _ => character = Some(x.to_owned())
+            _ => character = Some(x.to_owned()),
         });
         Self {
             shift,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,3 +4,8 @@ use std::env;
 pub(crate) fn is_wayland() -> bool {
     env::var("WAYLAND_DISPLAY").is_ok()
 }
+
+#[cfg(target_os = "linux")]
+pub(crate) fn use_xdg_on_x11() -> bool {
+    env::var("VENBIND_USE_XDG_PORTAL").is_ok()
+}


### PR DESCRIPTION
Right now it just falls back on xcb when the portal isn't supported. 
I also have allowed to pass through the required variables needed when using wayland. 
This also allows the X server to use the portal path if supported.

I have not tested it with the upstream patches to vencord.


Marked as draft, as I'm still working on getting the actual portal implementation working. 